### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-sink-websocket/README.adoc
+++ b/spring-cloud-starter-stream-sink-websocket/README.adoc
@@ -67,7 +67,7 @@ Handling message: GenericMessage [payload=2015-10-21 12:52:55, headers={id=18b88
 == Actuators
 There is an `Endpoint` that you can use to access the last `n` messages sent and received. You have to
  enable it by providing `--endpoints.websocketsinktrace.enabled=true`. By default it shows the last 100 messages via the
-`http://host:port/websocketsinktrace`. Here is a sample output:
+`https://host:port/websocketsinktrace`. Here is a sample output:
 
 ```
  [
@@ -94,7 +94,7 @@ There is an `Endpoint` that you can use to access the last `n` messages sent and
 ```
 
 There is also a simple HTML page where you see forwarded messages in a text area. You can access
-it directly via  `http://host:port` in your browser
+it directly via  `https://host:port` in your browser
 
 
 NOTE: For SSL mode (`--ssl=true`) a self signed certificate is used that might cause troubles with some

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerHandler.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerHandler.java
@@ -51,7 +51,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import io.netty.util.CharsetUtil;
 
 /**
- * Handles handshakes and messages. Based on the Netty <a href="http://bit.ly/1jVBj5T">websocket examples</a>.
+ * Handles handshakes and messages. Based on the Netty <a href="https://bit.ly/1jVBj5T">websocket examples</a>.
  *
  * @author Netty Project
  * @author Oliver Moser


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://host:port (UnknownHostException) with 1 occurrences migrated to:  
  https://host:port ([https](https://host:port) result UnknownHostException).
* [ ] http://host:port/websocketsinktrace (UnknownHostException) with 1 occurrences migrated to:  
  https://host:port/websocketsinktrace ([https](https://host:port/websocketsinktrace) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://bit.ly/1jVBj5T with 1 occurrences migrated to:  
  https://bit.ly/1jVBj5T ([https](https://bit.ly/1jVBj5T) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).