### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkConfiguration.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServer.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerHandler.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerHandler.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerInitializer.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkServerInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/actuator/WebsocketSinkTraceEndpoint.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/actuator/WebsocketSinkTraceEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/trace/InMemoryTraceRepository.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/trace/InMemoryTraceRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/trace/Trace.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/sink/trace/Trace.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-websocket/src/test/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-websocket/src/test/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/source/WebsocketSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/source/WebsocketSourceConfiguration.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/source/WebsocketSourceProperties.java
+++ b/spring-cloud-starter-stream-source-websocket/src/main/java/org/springframework/cloud/stream/app/websocket/source/WebsocketSourceProperties.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-websocket/src/test/java/org/springframework/cloud/stream/app/websocket/source/WebSocketSourceIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-websocket/src/test/java/org/springframework/cloud/stream/app/websocket/source/WebSocketSourceIntegrationTests.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 13 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).